### PR TITLE
adding checkout repository step

### DIFF
--- a/.github/workflows/scheduled-run.yml
+++ b/.github/workflows/scheduled-run.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+          
+      - name: check out repository code
+        uses: actions/checkout@v2
+        
       - name: execute py script
         run:
           python daily-update.py


### PR DESCRIPTION
@veirs In order to find the file, one needs an extra step to "checkout the repository". I have added it and it should work now. I suggest that you also add the option [`on: workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch). This allows you to trigger the workflow manually and is particularly useful for dev testing: you do not have to wait for the scheduled time to come to see the outcome.